### PR TITLE
Comments to url

### DIFF
--- a/packages/quorini-core/src/index.ts
+++ b/packages/quorini-core/src/index.ts
@@ -7,19 +7,20 @@ interface Config {
 const QClient = (() => {
     let config: Config = {};
     let mode: 'dev' | 'prod' = 'dev'; // Default mode is `dev`
+    
+    // here we work only with customer url
+
+    // it should be same style as frontend, you can check in PR
+    // ${process.env.REACT_APP_CUSTOMER_AUTH_API}/${ctx.projectId}/log-in${ctx.gqlSimulator.env !== "production" ? `?env=${ctx.gqlSimulator.env}` : ""}
 
     const privateUrls = {
         dev: {
-            apiUrl: "https://nq3o4t9ax0.execute-api.us-west-2.amazonaws.com/development",
-            authApiUrl: "https://vlpw2q6zt5.execute-api.us-west-2.amazonaws.com/development",
-            apiCustomerUrl: "https://h5ti6dtzyl.execute-api.us-west-2.amazonaws.com/development",
-            authApiCustomerUrl: "https://hth72i9z93.execute-api.us-west-2.amazonaws.com/development",
+            apiUrl: "https://h5ti6dtzyl.execute-api.us-west-2.amazonaws.com/",
+            authApiUrl: "https://hth72i9z93.execute-api.us-west-2.amazonaws.com/development",
         },
         prod: {
-            apiUrl: "https://api.quorini.app",
-            authApiUrl: "https://auth.quorini.app",
-            apiCustomerUrl: "https://api.quorini.io",
-            authApiCustomerUrl: "https://auth.quorini.io",
+            apiUrl: "https://api.quorini.io" + {config.projectId} ,
+            authApiUrl: "https://auth.quorini.io"  + {config.projectId},
         }
     };
 


### PR DESCRIPTION
@ernstchristian1202  I made this PR so we can have discussion in the code. No need to ever merge it, just wanted to show how url should look like (more or less) because now Auth happens with Quorini user, not with the Client User. 

1. We need `projectId` as compulsory variable in order to work with SDK


2.  in notion it was written -

```
QClient.config({
		projectId: "YOUR_PROJECT_ID",
		...
})
```

But the this code works with `QClient.configure` , 

Lets try to follow specification from [notion](https://www.notion.so/docs-quorini/Quorini-JS-TS-SDK-51f68f46340548a0a28186daceaf36db) 

Question to @tartachyov - what would be the dev env? 

I think adding `?env=${config.env}` should be enough..

